### PR TITLE
Upgrade HBase community connector for Dremio 4.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 To add the Dremio Community HBase Connector to the list of Dremio sources:
 
 1. From the project root, run `mvn clean install`. 
-   The HBase Connector `dremio-hbase-plugin-4.2.2-202004211133290458-b550b6fa.jar` appears in the `target` directory.
+   The HBase Connector `dremio-hbase-plugin-4.7.3-202008270723550726-918276ee.jar` appears in the `target` directory.
 
-1. Copy `dremio-hbase-plugin-4.2.2-202004211133290458-b550b6fa.jar` to the `<DREMIO_HOME>/jars` folder on all Dremio
+1. Copy `dremio-hbase-plugin-4.7.3-202008270723550726-918276ee.jar` to the `<DREMIO_HOME>/jars` folder on all Dremio
  nodes.
 
 1. Run `<DREMIO_HOME>/bin/stop` to stop Dremio.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 To add the Dremio Community HBase Connector to the list of Dremio sources:
 
 1. From the project root, run `mvn clean install`. 
-   The HBase Connector `dremio-hbase-plugin-4.7.3-202008270723550726-918276ee.jar` appears in the `target` directory.
+   The HBase Connector `dremio-hbase-plugin-<latest-version>.jar` appears in the `target` directory.
 
-1. Copy `dremio-hbase-plugin-4.7.3-202008270723550726-918276ee.jar` to the `<DREMIO_HOME>/jars` folder on all Dremio
+1. Copy `dremio-hbase-plugin-<latest-version>.jar` to the `<DREMIO_HOME>/jars` folder on all Dremio
  nodes.
 
 1. Run `<DREMIO_HOME>/bin/stop` to stop Dremio.

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,6 @@
 
   <properties>
     <hbase.TestSuite>**/HBaseTestsSuite.class</hbase.TestSuite>
-    <version.dremio>4.7.3-202008270723550726-918276ee</version.dremio>
   </properties>
 
   <dependencies>
@@ -48,7 +47,7 @@
     <dependency>
       <groupId>com.dremio.sabot</groupId>
       <artifactId>dremio-sabot-kernel</artifactId>
-      <version>${version.dremio}</version>
+      <version>${project.version}</version>
       <exclusions>
         <exclusion>
           <artifactId>hadoop-common</artifactId>
@@ -72,7 +71,7 @@
     <!-- <dependency>
       <groupId>com.dremio.sabot</groupId>
       <artifactId>dremio-sabot-kernel</artifactId>
-      <version>${version.dremio}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
       <exclusions>
@@ -85,7 +84,7 @@
     <dependency>
       <groupId>com.dremio</groupId>
       <artifactId>dremio-common</artifactId>
-      <version>${version.dremio}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency> -->
@@ -106,7 +105,7 @@
     <dependency>
       <groupId>com.dremio.services</groupId>
       <artifactId>dremio-services-namespace</artifactId>
-      <version>${version.dremio}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,14 +20,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.dremio.plugin</groupId>
-  <version>4.2.2-202004211133290458-b550b6fa</version>
+  <version>4.7.3-202008270723550726-918276ee</version>
   <artifactId>dremio-hbase-plugin</artifactId>
 
   <name>Dremio HBase Community Connector</name>
 
   <properties>
     <hbase.TestSuite>**/HBaseTestsSuite.class</hbase.TestSuite>
-    <version.dremio>4.2.2-202004211133290458-b550b6fa</version.dremio>
+    <version.dremio>4.7.3-202008270723550726-918276ee</version.dremio>
   </properties>
 
   <dependencies>

--- a/src/main/java/com/dremio/exec/expr/fn/impl/conv/OrderedBytesBigIntConvertTo.java
+++ b/src/main/java/com/dremio/exec/expr/fn/impl/conv/OrderedBytesBigIntConvertTo.java
@@ -15,10 +15,9 @@
  */
 package com.dremio.exec.expr.fn.impl.conv;
 
-import io.netty.buffer.ArrowBuf;
-
 import javax.inject.Inject;
 
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.holders.BigIntHolder;
 import org.apache.arrow.vector.holders.VarBinaryHolder;
 

--- a/src/main/java/com/dremio/exec/expr/fn/impl/conv/OrderedBytesBigIntDescConvertTo.java
+++ b/src/main/java/com/dremio/exec/expr/fn/impl/conv/OrderedBytesBigIntDescConvertTo.java
@@ -15,10 +15,9 @@
  */
 package com.dremio.exec.expr.fn.impl.conv;
 
-import io.netty.buffer.ArrowBuf;
-
 import javax.inject.Inject;
 
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.holders.BigIntHolder;
 import org.apache.arrow.vector.holders.VarBinaryHolder;
 

--- a/src/main/java/com/dremio/exec/expr/fn/impl/conv/OrderedBytesDoubleConvertTo.java
+++ b/src/main/java/com/dremio/exec/expr/fn/impl/conv/OrderedBytesDoubleConvertTo.java
@@ -15,10 +15,9 @@
  */
 package com.dremio.exec.expr.fn.impl.conv;
 
-import io.netty.buffer.ArrowBuf;
-
 import javax.inject.Inject;
 
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.holders.Float8Holder;
 import org.apache.arrow.vector.holders.VarBinaryHolder;
 

--- a/src/main/java/com/dremio/exec/expr/fn/impl/conv/OrderedBytesDoubleDescConvertTo.java
+++ b/src/main/java/com/dremio/exec/expr/fn/impl/conv/OrderedBytesDoubleDescConvertTo.java
@@ -15,10 +15,9 @@
  */
 package com.dremio.exec.expr.fn.impl.conv;
 
-import io.netty.buffer.ArrowBuf;
-
 import javax.inject.Inject;
 
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.holders.Float8Holder;
 import org.apache.arrow.vector.holders.VarBinaryHolder;
 

--- a/src/main/java/com/dremio/exec/expr/fn/impl/conv/OrderedBytesFloatConvertTo.java
+++ b/src/main/java/com/dremio/exec/expr/fn/impl/conv/OrderedBytesFloatConvertTo.java
@@ -15,10 +15,9 @@
  */
 package com.dremio.exec.expr.fn.impl.conv;
 
-import io.netty.buffer.ArrowBuf;
-
 import javax.inject.Inject;
 
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.holders.Float4Holder;
 import org.apache.arrow.vector.holders.VarBinaryHolder;
 

--- a/src/main/java/com/dremio/exec/expr/fn/impl/conv/OrderedBytesFloatDescConvertTo.java
+++ b/src/main/java/com/dremio/exec/expr/fn/impl/conv/OrderedBytesFloatDescConvertTo.java
@@ -15,10 +15,9 @@
  */
 package com.dremio.exec.expr.fn.impl.conv;
 
-import io.netty.buffer.ArrowBuf;
-
 import javax.inject.Inject;
 
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.holders.Float4Holder;
 import org.apache.arrow.vector.holders.VarBinaryHolder;
 

--- a/src/main/java/com/dremio/exec/expr/fn/impl/conv/OrderedBytesIntConvertTo.java
+++ b/src/main/java/com/dremio/exec/expr/fn/impl/conv/OrderedBytesIntConvertTo.java
@@ -15,10 +15,9 @@
  */
 package com.dremio.exec.expr.fn.impl.conv;
 
-import io.netty.buffer.ArrowBuf;
-
 import javax.inject.Inject;
 
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.holders.IntHolder;
 import org.apache.arrow.vector.holders.VarBinaryHolder;
 

--- a/src/main/java/com/dremio/exec/expr/fn/impl/conv/OrderedBytesIntDescConvertTo.java
+++ b/src/main/java/com/dremio/exec/expr/fn/impl/conv/OrderedBytesIntDescConvertTo.java
@@ -15,10 +15,9 @@
  */
 package com.dremio.exec.expr.fn.impl.conv;
 
-import io.netty.buffer.ArrowBuf;
-
 import javax.inject.Inject;
 
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.holders.IntHolder;
 import org.apache.arrow.vector.holders.VarBinaryHolder;
 


### PR DESCRIPTION
- Updated README.md to reference Dremio release 4.7.3-202008270723550726-918276ee.
- Updated converters to use org.apache.arrow.memory.ArrowBuf. 