### PR TITLE
Bugfix dx 64278 compilation 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![Build Status](https://travis-ci.org/dremio-hub/dremio-hbase-connector.svg?branch=master)](https://travis-ci.org/dremio-hub/dremio-hbase-connector)
 
+## Compatibility Notice
+
+As of April 6, 2023, the connector no longer compiles with Dremio OSS versions older than 24.0.0 due to a change in Dremio. Please make sure to use Dremio OSS version 24.0.0 or later if you want to use the Dremio community HBase connector.
+
 ## Building and Installation
 
 To add the Dremio Community HBase Connector to the list of Dremio sources:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 ## Compatibility Notice
 
-As of April 6, 2023, the connector no longer compiles with Dremio OSS versions older than 24.0.0 due to a change in Dremio. Please make sure to use Dremio OSS version 24.0.0 or later if you want to use the Dremio community HBase connector.
+Connector is compatible with Dremio versions 24.0 and later.
+
+Use [HBase v1.0.0 connector](https://github.com/dremio-hub/dremio-hbase-connector/releases/tag/v1.0.0) with earlier versions of Dremio.
 
 ## Building and Installation
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 [![Build Status](https://travis-ci.org/dremio-hub/dremio-hbase-connector.svg?branch=master)](https://travis-ci.org/dremio-hub/dremio-hbase-connector)
 
-## Compatibility Notice
-
-As of April 6, 2023, the connector no longer compiles with Dremio OSS versions older than 24.0.0 due to a change in Dremio. Please make sure to use Dremio OSS version 24.0.0 or later if you want to use the Dremio community HBase connector.
-
 ## Building and Installation
 
 To add the Dremio Community HBase Connector to the list of Dremio sources:

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <hbase.TestSuite>**/HBaseTestsSuite.class</hbase.TestSuite>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.dremio>21.1.1-202204292111390812-57b1832f</version.dremio>
+    <version.dremio>24.0.0-202302100528110223-3a169b7c</version.dremio>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <hbase.TestSuite>**/HBaseTestsSuite.class</hbase.TestSuite>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.dremio>24.0.0-202302100528110223-3a169b7c</version.dremio>
+    <version.dremio>21.1.1-202204292111390812-57b1832f</version.dremio>
   </properties>
 
   <dependencies>

--- a/src/main/java/com/dremio/exec/store/hbase/HBaseScanDrel.java
+++ b/src/main/java/com/dremio/exec/store/hbase/HBaseScanDrel.java
@@ -28,13 +28,14 @@ import com.dremio.exec.catalog.StoragePluginId;
 import com.dremio.exec.planner.common.ScanRelBase;
 import com.dremio.exec.planner.logical.Rel;
 import com.dremio.exec.store.TableMetadata;
+import com.google.common.collect.ImmutableList;
 
 public class HBaseScanDrel extends ScanRelBase implements Rel {
 
   public HBaseScanDrel(RelOptCluster cluster, RelTraitSet traitSet, RelOptTable table,
       StoragePluginId pluginId, TableMetadata tableMetadata, List<SchemaPath> projectedColumns,
       double observedRowcountAdjustment) {
-    super(cluster, traitSet, table, pluginId, tableMetadata, projectedColumns, observedRowcountAdjustment);
+    super(cluster, traitSet, table, pluginId, tableMetadata, projectedColumns, observedRowcountAdjustment,  ImmutableList.of());
   }
 
   @Override

--- a/src/main/java/com/dremio/exec/store/hbase/HBaseScanDrel.java
+++ b/src/main/java/com/dremio/exec/store/hbase/HBaseScanDrel.java
@@ -28,14 +28,13 @@ import com.dremio.exec.catalog.StoragePluginId;
 import com.dremio.exec.planner.common.ScanRelBase;
 import com.dremio.exec.planner.logical.Rel;
 import com.dremio.exec.store.TableMetadata;
-import com.google.common.collect.ImmutableList;
 
 public class HBaseScanDrel extends ScanRelBase implements Rel {
 
   public HBaseScanDrel(RelOptCluster cluster, RelTraitSet traitSet, RelOptTable table,
       StoragePluginId pluginId, TableMetadata tableMetadata, List<SchemaPath> projectedColumns,
       double observedRowcountAdjustment) {
-    super(cluster, traitSet, table, pluginId, tableMetadata, projectedColumns, observedRowcountAdjustment,  ImmutableList.of());
+    super(cluster, traitSet, table, pluginId, tableMetadata, projectedColumns, observedRowcountAdjustment);
   }
 
   @Override

--- a/src/main/java/com/dremio/exec/store/hbase/HBaseScanDrel.java
+++ b/src/main/java/com/dremio/exec/store/hbase/HBaseScanDrel.java
@@ -28,13 +28,14 @@ import com.dremio.exec.catalog.StoragePluginId;
 import com.dremio.exec.planner.common.ScanRelBase;
 import com.dremio.exec.planner.logical.Rel;
 import com.dremio.exec.store.TableMetadata;
+import com.google.common.collect.ImmutableList;
 
 public class HBaseScanDrel extends ScanRelBase implements Rel {
 
   public HBaseScanDrel(RelOptCluster cluster, RelTraitSet traitSet, RelOptTable table,
       StoragePluginId pluginId, TableMetadata tableMetadata, List<SchemaPath> projectedColumns,
       double observedRowcountAdjustment) {
-    super(cluster, traitSet, table, pluginId, tableMetadata, projectedColumns, observedRowcountAdjustment);
+    super(cluster, traitSet, table, pluginId, tableMetadata, projectedColumns, observedRowcountAdjustment, ImmutableList.of());
   }
 
   @Override

--- a/src/main/java/com/dremio/exec/store/hbase/HBaseScanPrel.java
+++ b/src/main/java/com/dremio/exec/store/hbase/HBaseScanPrel.java
@@ -59,7 +59,7 @@ public class HBaseScanPrel extends ScanPrelBase {
       byte[] startRow,
       byte[] stopRow,
       byte[] filter) {
-    super(cluster, traitSet, table, dataset.getStoragePluginId(), dataset, projectedColumns, observedRowcountAdjustment, ImmutableList.of(), ImmutableList.of());
+    super(cluster, traitSet, table, dataset.getStoragePluginId(), dataset, projectedColumns, observedRowcountAdjustment, ImmutableList.of());
     this.filter = filter;
     this.startRow = startRow;
     this.stopRow = stopRow;

--- a/src/main/java/com/dremio/exec/store/hbase/HBaseScanPrel.java
+++ b/src/main/java/com/dremio/exec/store/hbase/HBaseScanPrel.java
@@ -59,7 +59,7 @@ public class HBaseScanPrel extends ScanPrelBase {
       byte[] startRow,
       byte[] stopRow,
       byte[] filter) {
-    super(cluster, traitSet, table, dataset.getStoragePluginId(), dataset, projectedColumns, observedRowcountAdjustment, ImmutableList.of());
+    super(cluster, traitSet, table, dataset.getStoragePluginId(), dataset, projectedColumns, observedRowcountAdjustment, ImmutableList.of(), ImmutableList.of());
     this.filter = filter;
     this.startRow = startRow;
     this.stopRow = stopRow;


### PR DESCRIPTION
- updating the call to the ScanPrelBase constructor in HBaseScanPrel&HBaseScanDrel to match up with the updated signature, as additional arguments are required
- updating the default dremio version to be the latest release of dremio oss (24.0.0)
- updating the README to include a compatibility notice as this change will lead to the hbase community connector no longer working with older versions of dremio, which uses the older signature of the aforementioned constructor